### PR TITLE
Change homepage to reflect Athena is for girls or girl-identifying, not girls or non-binary teenagers.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,48 +4,49 @@ import Background from "@/components/Background";
 import PlausibleProvider from "next-plausible";
 
 export const metadata: Metadata = {
-  title: "Athena - Hack Club",
-  description: "Athena is a group of programs at Hack Club to empower girls and nonbinary teenagers to code.",
-  icons: "https://assets.hackclub.com/icon-rounded.svg",
-  openGraph: {
-    title: "Athena - Hack Club",
-    description: "Athena is a group of programs at Hack Club to empower girls and nonbinary teenagers to code.",
-    images: [
-      {
-        url: "/thumbnail.png",
-        width: 1200,
-        height: 630,
-        alt: "Athena - Hack Club"
-      }
-    ],
-    type: "website",
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Athena - Hack Club",
-    description: "Athena is a group of programs at Hack Club to empower girls and nonbinary teenagers to code.",
-    images: ["/thumbnail.png"],
-    creator: "@hackclub"
-  }
+	title: "Athena - Hack Club",
+	description:
+		"Athena is a group of programs at Hack Club to empower girls and nonbinary teenagers to code.",
+	icons: "https://assets.hackclub.com/icon-rounded.svg",
+	openGraph: {
+		title: "Athena - Hack Club",
+		description:
+			"Athena is a group of programs at Hack Club to empower girls and girl-identifying teenagers to code.",
+		images: [
+			{
+				url: "/thumbnail.png",
+				width: 1200,
+				height: 630,
+				alt: "Athena - Hack Club",
+			},
+		],
+		type: "website",
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "Athena - Hack Club",
+		description:
+			"Athena is a group of programs at Hack Club to empower girls and and girl-identifying teenagers to code.",
+		images: ["/thumbnail.png"],
+		creator: "@hackclub",
+	},
 };
 
 export default function RootLayout({
-  children,
+	children,
 }: Readonly<{
-  children: React.ReactNode;
+	children: React.ReactNode;
 }>) {
-  return (
-    <html lang="en">
-      <body
-        className="antialiased"
-      >
-        <PlausibleProvider domain="athena.hackclub.com">
-          <Background>
-            {children}
-            {/* <div className="w-screen p-6 bg-red"></div> */}
-          </Background>
-        </PlausibleProvider>
-      </body>
-    </html>
-  );
+	return (
+		<html lang="en">
+			<body className="antialiased">
+				<PlausibleProvider domain="athena.hackclub.com">
+					<Background>
+						{children}
+						{/* <div className="w-screen p-6 bg-red"></div> */}
+					</Background>
+				</PlausibleProvider>
+			</body>
+		</html>
+	);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ export default async function Home() {
       <div className="w-full text-left px-6 lg:px-32 mb-16">
         <hr className = "py-10"/>
         <div className="text-6xl md:text-9xl font-bold">Athena</div>
-        <div className="text-xl md:text-3xl font-bold mt-2">is a group of programs at Hack Club to empower girls and nonbinary teenagers to code.</div>
+        <div className="text-xl md:text-3xl font-bold mt-2">is a group of programs at Hack Club to empower teenage girls to code.</div>
         <div className="text-base md:text-lg">From hosting in-person hackathons to virtual workshops, Hack Club is a place to become more technical and immerse yourself in coding.</div>
         
         <div className='w-full h-fit grid lg:grid-rows-1 grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-8 my-8'>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ export default async function Home() {
       <div className="w-full text-left px-6 lg:px-32 mb-16">
         <hr className = "py-10"/>
         <div className="text-6xl md:text-9xl font-bold">Athena</div>
-        <div className="text-xl md:text-3xl font-bold mt-2">is a group of programs at Hack Club to empower teenage girls to code.</div>
+        <div className="text-xl md:text-3xl font-bold mt-2">is a group of programs at Hack Club to empower girls or girl-identifying teenagers to code.</div>
         <div className="text-base md:text-lg">From hosting in-person hackathons to virtual workshops, Hack Club is a place to become more technical and immerse yourself in coding.</div>
         
         <div className='w-full h-fit grid lg:grid-rows-1 grid-cols-1 md:grid-cols-3 lg:grid-cols-6 gap-8 my-8'>


### PR DESCRIPTION
Hi there. If you've come here from an archived gitlab page or otherwise: I did not consent to being on that. **Please email me at raygenrrupe@gmail.com the site and how you found it.** Not a single person who was screenshotted is OK with their messages being shared publicly like that. The gitlab is also full of misinformation and out of context messaging, created by someone who did not and still does not understand the entire situation surrounding Athena. Please--try and get that archive removed, and don't support people who are linking you to it.




"girls and nonbinary teenagers" has been changed to "girls or girl-identifying teenagers", in line with the rules for Sleepover, as stated by Christina Asquith.

<img width="795" height="579" alt="image" src="https://github.com/user-attachments/assets/02d87eb0-d2dc-4732-b2aa-2cec98ac89ae" />